### PR TITLE
Adapt type changes, make admin-ui buildable, add "getting started" steps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This project demonstrates a real-world [Vendure](https://www.vendure.io/) server
 2. `yarn` to install dependencies
 3. `yarn populate` to populate the database with some sample data
 4. In the `/src/ui-extensions/react-app` directory, run `yarn` and then `yarn build`
-3. In the root dir, run `yarn start` to start the Vendure server
+5. In the root dir, run `yarn build` to build the application 
+6. Run `yarn start` to start the Vendure server
 
 ## Tooling
 

--- a/populate.ts
+++ b/populate.ts
@@ -26,9 +26,6 @@ if (require.main === module) {
             importExportOptions: {
                 importAssetsDir: resolveFromCreatePackage('assets/images'),
             },
-            workerOptions: {
-                runInMainProcess: true,
-            },
             customFields: {},
             plugins: config.plugins!.filter(plugin => plugin !== AdminUiPlugin),
         }),
@@ -69,7 +66,7 @@ async function populateReview(config: RuntimeVendureConfig) {
             submitProductReview(input: {
                 productId: "1",
                 summary: "A great laptop!",
-                body: "The laptop looks great an performance is flawless."
+                body: "The laptop looks great an performance is flawless.",
                 rating: 5,
                 authorName: "Randall M",
                 authorLocation: "Vienna",

--- a/src/plugins/reviews/e2e/config/e2e-initial-data.ts
+++ b/src/plugins/reviews/e2e/config/e2e-initial-data.ts
@@ -13,6 +13,7 @@ export const initialData: InitialData = {
         { name: 'Standard Shipping', price: 500 },
         { name: 'Express Shipping', price: 1000 },
     ],
+    paymentMethods: [],
     countries: [
         { name: 'Australia', code: 'AU', zone: 'Oceania' },
         { name: 'Austria', code: 'AT', zone: 'Europe' },


### PR DESCRIPTION
The real-world-example wasn't populating and building because of changes to the types in the beta version:
- populate.ts VendureConfig: workerOptions removed
- initial data: paymentMethods added (empty – does something belong here?)

Also added the build step to the Getting Started parapgrah in the readme, without the Vendure server wouldn't start.