### PR TITLE
lint:fix recursive

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "migration:generate": "ts-node migration generate",
     "migration:run": "ts-node migration run",
     "migration:revert": "ts-node migration revert",
-    "lint:fix": "eslint ./src/**/*.ts --fix",
+    "lint:fix": "eslint ./src/ --ext .ts --fix",
     "e2e:reviews": "jest --config src/plugins/reviews/e2e/config/jest-config.js"
   },
   "dependencies": {


### PR DESCRIPTION
The script `lint:fix` in package.json used a glob which wasn't recursive, hence not touching files in folders deeper than direct src-subfolders.