### PR TITLE
Added --runInBand option

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "migration:run": "ts-node migration run",
     "migration:revert": "ts-node migration revert",
     "lint:fix": "eslint ./src/ --ext .ts --fix",
-    "e2e:reviews": "jest --config src/plugins/reviews/e2e/config/jest-config.js"
+    "e2e:reviews": "jest --config src/plugins/reviews/e2e/config/jest-config.js --runInBand"
   },
   "dependencies": {
     "@vendure/admin-ui-plugin": "^1.0.0-beta.2",


### PR DESCRIPTION
Added `--runInBand` option as people tend to forget about that once adding another e2e test.

While reading that conversation: https://vendure-ecommerce.slack.com/archives/CKYMF0ZTJ/p1618495800361200 I remembered that I also had troubles with this issue. This repository usally is the first one checked when a person starts developing with vendure. Therefore I beliefe that this option should already be present, to learn from it and to remove later possible barriers.